### PR TITLE
Refine logging

### DIFF
--- a/app/logger.py
+++ b/app/logger.py
@@ -67,6 +67,6 @@ def setup_logging(app_name: str, version: str, log_level: str) -> None:
         logging.getLogger(_log).handlers.clear()
         logging.getLogger(_log).propagate = True
 
-    # Uvicorn logs are re-emitted with more context. We effectively silence them here
+    # Silence uvicorn access log. We create a more context specific log
     logging.getLogger("uvicorn.access").handlers.clear()
     logging.getLogger("uvicorn.access").propagate = False

--- a/app/middleware.py
+++ b/app/middleware.py
@@ -26,9 +26,8 @@ active_request_gauge = Gauge(
 )
 
 
-# app and access loggers
+# get app logger
 app_logger = structlog.stdlib.get_logger("app_logs")
-access_logger = structlog.stdlib.get_logger("access_logs")
 
 # url segment approved_list for sanitization
 approved_list = ["ping", "metrics", "widget", "exception"]
@@ -97,22 +96,25 @@ class InstrumentationMiddleware:
             # increment counter
             request_counter.labels(info["status_code"], http_method, route).inc()
 
-            # Recreate the Uvicorn access log format, but add all parameters as structured information
-            url = get_path_with_query_string(scope)
-            client_host, client_port = scope["client"]
-            http_version = scope["http_version"]
-            access_logger.info(
-                f"""{client_host}:{client_port} - "{http_method} {scope["path"]} HTTP/{http_version}" {info["status_code"]}""",
-                http={
-                    "url": str(url),
-                    "status_code": info["status_code"],
-                    "method": http_method,
-                    "request_id": correlation_id.get(),
-                    "version": http_version,
-                },
-                network={"client": {"ip": client_host, "port": client_port}},
-                duration=process_time,
-            )
+            # Create an app log for "Request IN" that includes basic request information for every request except
+            # those for /ping /health /metrics endpoints
+            path = scope["path"]
+            if path in ["/ping", "/health", "/metrics"]:
+                url = get_path_with_query_string(scope)
+                client_host, client_port = scope["client"]
+                http_version = scope["http_version"]
+                app_logger.info(
+                    f"""{client_host}:{client_port} - "{http_method} {path} HTTP/{http_version}" {info["status_code"]}""",
+                    http={
+                        "url": str(url),
+                        "status_code": info["status_code"],
+                        "method": http_method,
+                        "request_id": correlation_id.get(),
+                        "version": http_version,
+                    },
+                    network={"client": {"ip": client_host, "port": client_port}},
+                    duration=process_time,
+                )
 
 # sanitize_url replaces segments of the path with an asterisk if that segment is not in the approved_list
 # we do this so we can track metrics by endpoint rather than by unique url

--- a/app/middleware.py
+++ b/app/middleware.py
@@ -104,7 +104,7 @@ class InstrumentationMiddleware:
                 client_host, client_port = scope["client"]
                 http_version = scope["http_version"]
                 app_logger.info(
-                    f"""{client_host}:{client_port} - "{http_method} {path} HTTP/{http_version}" {info["status_code"]}""",
+                    f"Request IN - {path}",
                     http={
                         "url": str(url),
                         "status_code": info["status_code"],

--- a/app/middleware.py
+++ b/app/middleware.py
@@ -68,6 +68,7 @@ class InstrumentationMiddleware:
             active_request_gauge.labels(scope["method"], sanitize_url(scope["path"], approved_list)).inc()
             await self.app(scope, receive, inner_send)
         except Exception as e:
+            # catch unhandled exceptions
             app_logger.exception(
                 "An unhandled exception was caught by last resort middleware",
                 exception_class=e.__class__.__name__,


### PR DESCRIPTION
Winnow down to one logger for the app - "app_logs". Emit access style logs as a "Request IN - {path)" messaged log and ignore /ping /health and /metrics requests.